### PR TITLE
DynJS compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,10 @@ var browserslist = function (selections, opts) {
         name1 = name1.split(' ');
         name2 = name2.split(' ');
         if ( name1[0] === name2[0] ) {
-            return parseFloat(name2[1]) - parseFloat(name1[1]);
+            var d = parseFloat(name2[1]) - parseFloat(name1[1]);
+            if (d > 0) return 1;
+            else if (d < 0) return -1;
+            else return 0;
         } else {
             return name1[0].localeCompare(name2[0]);
         }


### PR DESCRIPTION
DynJS (http://dynjs.org/) fails on this code because this sort function sometimes returns floating point values, and it's a bit more strict than other engines about requiring integer values. This change makes the module work in DynJS, and other existing JS engines will also be fine with it.