### PR TITLE
Add the possibility to query for browser capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ major browser, or have a usage of over 10% in global usage statistics:
 
 ```js
 browserslist('last 1 version, > 10%');
-//=> ['and_chr 46', 'chrome 46', 'chrome 45', 'edge 12', 'firefox 41'
-//    'ie 11', 'ie_mob 11', 'ios_saf 9', 'opera 32', 'safari 9']
+//=> ['and_chr 47', 'chrome 47', 'chrome 46', 'edge 13', 'firefox 43',
+//    'ie 11', 'ie_mob 11', 'ios_saf 9.0-9.2', 'opera 34', 'safari 9']
 ```
 
 Multiple criteria are combined as a boolean OR. In other words, a browser

--- a/README.md
+++ b/README.md
@@ -49,8 +49,12 @@ You can specify the versions by queries (case insensitive):
 * `Firefox <= 20`: versions of Firefox less than or equal to 20.
 * `Firefox ESR`: the latest [Firefox ESR] version.
 * `iOS 7`: the iOS browser version 7 directly.
+* `support css-gradients`: all browser versions that support to some extent the given feature (in this case, CSS Gradients)
+* `full support css-gradients`: all browser versions that _fully_ support the given feature (in this case, CSS Gradients)
 * `not ie <= 8`: exclude browsers selected before by this query.
   You can add `not ` to any query.
+
+To see the list of features that you can query for, visit http://caniuse.com
 
 Blackberry and Android WebView will not be used in `last n versions`.
 You should add them by name.

--- a/index.js
+++ b/index.js
@@ -389,12 +389,14 @@ browserslist.queries = {
             }
             for ( var name in data ) {
                 for ( var version in data[name] ) {
-                    // See caniuse-db/CONTRIBUTING.md for details on the support string format.
-                    // 'y' means supported, 'a' means partially supported, and the rest we don't care about
+                    // See caniuse-db/CONTRIBUTING.md for details on the
+                    // support string format. 'y' means supported, 'a' means
+                    // partially supported, and the rest we don't care about
                     // (vendor prefix needed, unknown support, no support, etc)
                     var support = data[name][version].split(' ');
                     for ( var i = 0; i < support.length; i++ ) {
-                        if (support[i] === 'y' || (support[i] === 'a' && !fullSupportRequired)) {
+                        if (support[i] === 'y' ||
+                            support[i] === 'a' && !fullSupportRequired) {
                             result.push(name + ' ' + version);
                             break;
                         }

--- a/test/test.js
+++ b/test/test.js
@@ -85,8 +85,8 @@ describe('browserslist', function () {
 
     it('has actual example in README.md', function () {
         expect(browserslist('last 1 version, > 10%')).to.eql(
-            ['and_chr 46', 'chrome 46', 'chrome 45', 'edge 12', 'firefox 41',
-             'ie 11', 'ie_mob 11', 'ios_saf 9', 'opera 32', 'safari 9']);
+            ['and_chr 47', 'chrome 47', 'chrome 46', 'edge 13', 'firefox 43',
+             'ie 11', 'ie_mob 11', 'ios_saf 9.0-9.2', 'opera 34', 'safari 9']);
     });
 
     it('throws custom error', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -360,6 +360,44 @@ describe('browserslist', function () {
 
     });
 
+    describe('feature query', function () {
+
+        beforeEach(function () {
+            browserslist.features = {
+                websockets: {
+                    'ie': {
+                        '5':  'u',
+                        '6':  'n',
+                        '7':  'd',
+                        '8':  'a x #1',
+                        '9':  'a',
+                        '10': '#2 y',
+                        '11': 'y'
+                    }
+                }
+            };
+        });
+
+        it('selects browsers which support a feature', function () {
+            var result = ['ie 11', 'ie 10', 'ie 9', 'ie 8'];
+            expect(browserslist('support websockets')).to.eql(result);
+            expect(browserslist('supports websockets')).to.eql(result);
+        });
+
+        it('selects browsers which completely support a feature', function () {
+            var result = ['ie 11', 'ie 10'];
+            expect(browserslist('full support websockets')).to.eql(result);
+            expect(browserslist('fully support websockets')).to.eql(result);
+            expect(browserslist('fully supports websockets')).to.eql(result);
+        });
+
+        it('raises on an unknown feature', function () {
+            expect(function () {
+                browserslist('supports potato-cannon');
+            }).to.throw(browserslist.Error, 'Unknown feature potato-cannon');
+        });
+    });
+
     describe('.parseConfig()', function () {
 
         it('parses queries', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -365,14 +365,14 @@ describe('browserslist', function () {
         beforeEach(function () {
             browserslist.features = {
                 websockets: {
-                    'ie': {
-                        '5':  'u',
-                        '6':  'n',
-                        '7':  'd',
-                        '8':  'a x #1',
-                        '9':  'a',
-                        '10': '#2 y',
-                        '11': 'y'
+                    ie: {
+                        5:  'u',
+                        6:  'n',
+                        7:  'd',
+                        8:  'a x #1',
+                        9:  'a',
+                        10: '#2 y',
+                        11: 'y'
                     }
                 }
             };


### PR DESCRIPTION
**New queries:**
* `support <feature>` : Returns all the browser versions that support or partially support the given feature
* `supports <feature>` : Same as above
* `full support <feature>` : Returns all the browser versions with complete support for the given feature
* `fully supports <feature>` : same as above

**Rationale:**
To put it simply: If my webapp uses WebSockets, there is no point on generating CSS prefixes for IE8. I'ts a common use case to try to make the webapp compatible with as much browsers as possible, but if it uses a new technology, trying to run it in older browsers would break anyway. So, for the WebSockets example, one could query browserlist with `"supports websockets"` and that would match all the browser versions that support the feature.

I found it useful for me, of course I'm open to suggestions or changes, but I think this query adds more flexibility to the library.

The query uses the caniuse database. `"support <feature>"` matches partial and full support (the most common use case, since partial support of most features just means that a vendor prefix is needed or that some advanced usage of the feature is not possible), and `"full support <feature>"` matches only full support.

**Note:** This would be more useful if there was a way to compute queries with the boolean "AND" operation, such as `"supports websockets, and supports local-storage, and > 1%"`. Maybe that will be my next PR, if I manage to keep the logic reasonably simple.