### PR TITLE
Add extra fs safeguard checks in readConfig

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,7 +204,7 @@ browserslist.checkName = function (name) {
 // Find config, read file and parse it
 browserslist.readConfig = function (from) {
     if ( from === false )   return false;
-    if ( !fs.readFileSync ) return false;
+    if ( !fs.readFileSync || !fs.existsSync || !fs.statSync ) return false;
     if ( typeof from === 'undefined' ) from = '.';
 
     var dirs = path.resolve(from).split(path.sep);


### PR DESCRIPTION
Since readConfig calls existsSync and statSync it would be prudent to check for their existence first.

JSPM has a fledgling library implementing fs, https://github.com/jspm/nodelibs-fs/blob/master/fs.js, which causes a check for just `readFileSync` to be insufficient.