### PR TITLE
Added ability to get country-specific coverage data

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,9 +209,18 @@ You can get total users coverage for selected browsers by JS API:
 browserslist.coverage(browserslist('> 1%')) //=> 81.4
 ```
 
+```js
+browserslist.coverage(browserslist('> 1% in US'), 'US') //=> 83.1
+```
+
 Or by CLI:
 
 ```sh
 $ browserslist --coverage "> 1%"
 These browsers account for 81.4% of all users globally
+```
+
+```sh
+$ browserslist --coverage=US "> 1% in US"
+These browsers account for 83.1% of all users in the US
 ```

--- a/cli.js
+++ b/cli.js
@@ -10,6 +10,7 @@ function isArg(arg) {
     });
 }
 
+// Returns the value after an equals sign in an argument (or undefined).
 function getArgValue(arg) {
     var found = args.filter(function (str) {
         return str.indexOf(arg + '=') === 0;
@@ -58,10 +59,12 @@ if ( args.length === 0 || isArg('--help') || isArg('-h') ) {
     var country = getArgValue('--coverage') || getArgValue('-c');
     var result = browserslist.coverage(query(browsers), country);
     var round  = Math.round(result * 100) / 100.0;
+
     var where = 'globally';
     if (country && country !== 'global') {
         where = 'in the ' + country.toUpperCase();
     }
+
     process.stdout.write(
         'These browsers account for ' + round + '% of all users ' +
         where + '\n');

--- a/cli.js
+++ b/cli.js
@@ -5,7 +5,17 @@ var pkg          = require('./package.json');
 var args         = process.argv.slice(2);
 
 function isArg(arg) {
-    return args.indexOf(arg) >= 0;
+    return args.some(function (str) {
+        return str === arg || str.indexOf(arg + '=') === 0;
+    });
+}
+
+function getArgValue(arg) {
+    var found = args.filter(function (str) {
+        return str.indexOf(arg + '=') === 0;
+    })[0];
+    var value = found && found.split('=')[1];
+    return value && value.replace(/^['"]|['"]$/g, '');
 }
 
 function error(msg) {
@@ -45,10 +55,16 @@ if ( args.length === 0 || isArg('--help') || isArg('-h') ) {
         return i[0] !== '-';
     });
     if ( !browsers ) error('Define a browsers query to get coverage');
-    var result = browserslist.coverage(query(browsers));
+    var country = getArgValue('--coverage') || getArgValue('-c');
+    var result = browserslist.coverage(query(browsers), country);
     var round  = Math.round(result * 100) / 100.0;
+    var where = 'globally';
+    if (country && country !== 'global') {
+        where = 'in the ' + country.toUpperCase();
+    }
     process.stdout.write(
-        'These browsers account for ' + round + '% of all users globally\n');
+        'These browsers account for ' + round + '% of all users ' +
+        where + '\n');
 
 } else if ( args.length === 1 && args[0][0] !== '-' ) {
     query(args[0]).forEach(function (browser) {

--- a/index.js
+++ b/index.js
@@ -242,7 +242,11 @@ browserslist.coverage = function (browsers, country) {
         country = 'global';
     }
     return browsers.reduce(function (all, i) {
-        return all + browserslist.usage[country][i];
+        var usage = browserslist.usage[country][i];
+        if (usage === undefined) {
+            usage = browserslist.usage[country][i.replace(/ [\d.]+$/, ' 0')];
+        }
+        return all + (usage || 0);
     }, 0);
 };
 

--- a/index.js
+++ b/index.js
@@ -239,11 +239,14 @@ browserslist.coverage = function (browsers, country) {
         country = country.toUpperCase();
         loadCountryStatistics(country);
     } else {
-        country = 'global';
+        country = 'global'; // Default value
     }
+
     return browsers.reduce(function (all, i) {
         var usage = browserslist.usage[country][i];
         if (usage === undefined) {
+            // Sometimes, Caniuse consolidates country usage data into a single
+            // "version 0" entry. This is usually when there is only 1 version.
             usage = browserslist.usage[country][i.replace(/ [\d.]+$/, ' 0')];
         }
         return all + (usage || 0);

--- a/index.js
+++ b/index.js
@@ -150,6 +150,18 @@ var normalizeVersion = function (data, version) {
     }
 };
 
+var loadCountryStatistics = function (country) {
+    if (!browserslist.usage[country]) {
+        var usage = { };
+        var data = require(
+            'caniuse-db/region-usage-json/' + country + '.json');
+        for ( var i in data.data ) {
+            fillUsage(usage, i, data.data[i]);
+        }
+        browserslist.usage[country] = usage;
+    }
+};
+
 // Will be filled by Can I Use data below
 browserslist.data  = { };
 browserslist.usage = {
@@ -222,9 +234,15 @@ browserslist.readConfig = function (from) {
 };
 
 // Return browsers market coverage
-browserslist.coverage = function (browsers) {
+browserslist.coverage = function (browsers, country) {
+    if (country && country !== 'global') {
+        country = country.toUpperCase();
+        loadCountryStatistics(country);
+    } else {
+        country = 'global';
+    }
     return browsers.reduce(function (all, i) {
-        return all + browserslist.usage.global[i];
+        return all + browserslist.usage[country][i];
     }, 0);
 };
 
@@ -314,16 +332,8 @@ browserslist.queries = {
             country    = country.toUpperCase();
             var result = [];
 
+            loadCountryStatistics(country);
             var usage = browserslist.usage[country];
-            if ( !usage ) {
-                usage = { };
-                var data = require(
-                    'caniuse-db/region-usage-json/' + country + '.json');
-                for ( var i in data.data ) {
-                    fillUsage(usage, i, data.data[i]);
-                }
-                browserslist.usage[country] = usage;
-            }
 
             for ( var version in usage ) {
                 if ( usage[version] > popularity ) {

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -9,6 +9,10 @@ test.before(() => {
         global: {
             'ie 9':  5,
             'ie 10': 10.1
+        },
+        UK: {
+            'ie 9':  2,
+            'ie 10': 4.4
         }
     };
 });
@@ -23,4 +27,12 @@ test('returns browsers coverage', t => {
 
 test('returns zero coverage on empty browsers', t => {
     t.same(browserslist.coverage([]), 0);
+});
+
+test('returns usage in specified country', t => {
+    t.same(browserslist.coverage(['ie 10'], 'uk'), 4.4);
+});
+
+test('loads country usage data from Can I Use', t => {
+    t.ok(browserslist.coverage(['ie 9', 'ie 10'], 'us') > 0);
 });


### PR DESCRIPTION
Adding more to the `--coverage` feature (#51), this patch allows people to specify a specific country from which to calculate coverage data.

```sh
browserslist --coverage=US "> 1% in US"
# => These browsers account for 83.1% of all users in the US
```