### PR TITLE
Tighten up regexps, allow omission of whitespace around operators

### DIFF
--- a/index.js
+++ b/index.js
@@ -308,7 +308,7 @@ browserslist.queries = {
     },
 
     globalStatistics: {
-        regexp: /^>\s*(\d+\.?\d*)%$/,
+        regexp: /^>\s*(\d*\.?\d+)%$/,
         select: function (popularity) {
             popularity = parseFloat(popularity);
             var result = [];
@@ -324,7 +324,7 @@ browserslist.queries = {
     },
 
     customStatistics: {
-        regexp: /^>\s*(\d+\.?\d*)%\s+in\s+my\s+stats$/,
+        regexp: /^>\s*(\d*\.?\d+)%\s+in\s+my\s+stats$/,
         select: function (popularity) {
             popularity = parseFloat(popularity);
             var result = [];
@@ -345,7 +345,7 @@ browserslist.queries = {
     },
 
     countryStatistics: {
-        regexp: /^>\s*(\d+\.?\d*)%\s+in\s+(\w\w)$/,
+        regexp: /^>\s*(\d*\.?\d+)%\s+in\s+(\w\w)$/,
         select: function (popularity, country) {
             popularity = parseFloat(popularity);
             country    = country.toUpperCase();

--- a/index.js
+++ b/index.js
@@ -280,7 +280,7 @@ browserslist.parseConfig = function (string) {
 browserslist.queries = {
 
     lastVersions: {
-        regexp: /^last (\d+) versions?$/i,
+        regexp: /^last\s+(\d+)\s+versions?$/i,
         select: function (versions) {
             var selected = [];
             browserslist.major.forEach(function (name) {
@@ -298,7 +298,7 @@ browserslist.queries = {
     },
 
     lastByBrowser: {
-        regexp: /^last (\d+) (\w+) versions?$/i,
+        regexp: /^last\s+(\d+)\s+(\w+)\s+versions?$/i,
         select: function (versions, name) {
             var data = browserslist.checkName(name);
             return data.released.slice(-versions).map(function (v) {
@@ -308,7 +308,7 @@ browserslist.queries = {
     },
 
     globalStatistics: {
-        regexp: /^>\s?(\d+\.?\d*)%$/,
+        regexp: /^>\s*(\d+\.?\d*)%$/,
         select: function (popularity) {
             popularity = parseFloat(popularity);
             var result = [];
@@ -324,7 +324,7 @@ browserslist.queries = {
     },
 
     customStatistics: {
-        regexp: /^>\s?(\d+\.?\d*)% in my stats$/,
+        regexp: /^>\s*(\d+\.?\d*)%\s+in\s+my\s+stats$/,
         select: function (popularity) {
             popularity = parseFloat(popularity);
             var result = [];
@@ -345,7 +345,7 @@ browserslist.queries = {
     },
 
     countryStatistics: {
-        regexp: /^> (\d+\.?\d*)% in (\w\w)$/,
+        regexp: /^>\s*(\d+\.?\d*)%\s+in\s+(\w\w)$/,
         select: function (popularity, country) {
             popularity = parseFloat(popularity);
             country    = country.toUpperCase();
@@ -365,7 +365,7 @@ browserslist.queries = {
     },
 
     range: {
-        regexp: /^(\w+) ([\d\.]+)-([\d\.]+)/i,
+        regexp: /^(\w+)\s+([\d\.]+)\s*-\s*([\d\.]+)$/i,
         select: function (name, from, to) {
             var data = browserslist.checkName(name);
             from = parseFloat(normalizeVersion(data, from) || from);
@@ -383,7 +383,7 @@ browserslist.queries = {
     },
 
     versions: {
-        regexp: /^(\w+) (>=?|<=?)\s*([\d\.]+)/,
+        regexp: /^(\w+)\s*(>=?|<=?)\s*([\d\.]+)$/,
         select: function (name, sign, version) {
             var data = browserslist.checkName(name);
             var alias = normalizeVersion(data, version);
@@ -417,14 +417,14 @@ browserslist.queries = {
     },
 
     esr: {
-        regexp: /^(firefox|ff|fx) esr$/i,
+        regexp: /^(firefox|ff|fx)\s+esr$/i,
         select: function () {
             return ['firefox 45'];
         }
     },
 
     direct: {
-        regexp: /^(\w+) (tp|[\d\.]+)$/i,
+        regexp: /^(\w+)\s+(tp|[\d\.]+)$/i,
         select: function (name, version) {
             if ( /tp/i.test(version) ) version = 'TP';
             var data  = browserslist.checkName(name);

--- a/test/country.js
+++ b/test/country.js
@@ -33,3 +33,7 @@ test('fixes country case', t => {
 test('loads country from Can I Use', t => {
     t.truthy(browserslist('> 1% in RU').length > 0);
 });
+
+test('allows omission of the space between the > and the percentage', t => {
+    t.truthy(browserslist('>10% in US').length > 0);
+});

--- a/test/country.js
+++ b/test/country.js
@@ -26,6 +26,10 @@ test('works with float', t => {
     t.deepEqual(browserslist('> 10.2% in US'), ['ie 11']);
 });
 
+test('works with float that has a leading dot', t => {
+    t.deepEqual(browserslist('> .2% in US'), ['ie 11', 'ie 10', 'ie 9']);
+});
+
 test('fixes country case', t => {
     t.deepEqual(browserslist('> 10.2% in us'), ['ie 11']);
 });

--- a/test/global.js
+++ b/test/global.js
@@ -30,6 +30,10 @@ test('works with float', t => {
     t.deepEqual(browserslist('> 10.2%'), ['ie 11']);
 });
 
+test('works with float that has a leading dot', t => {
+    t.deepEqual(browserslist('> .2%'), ['ie 11', 'ie 10', 'ie 9']);
+});
+
 test('allows omission of the space between the > and the percentage', t => {
     t.deepEqual(browserslist('>10%'), ['ie 11', 'ie 10']);
 });

--- a/test/global.js
+++ b/test/global.js
@@ -29,3 +29,7 @@ test('accepts non-space query', t => {
 test('works with float', t => {
     t.deepEqual(browserslist('> 10.2%'), ['ie 11']);
 });
+
+test('allows omission of the space between the > and the percentage', t => {
+    t.deepEqual(browserslist('>10%'), ['ie 11', 'ie 10']);
+});

--- a/test/versions.js
+++ b/test/versions.js
@@ -53,3 +53,7 @@ test('works with joined versions from Can I Use', t => {
     t.deepEqual(browserslist('android >= 4.2'), ['android 4.2-4.3']);
     t.deepEqual(browserslist('android >= 4.3'), ['android 4.2-4.3']);
 });
+
+test('allows omission of the space around the operator', t => {
+    t.deepEqual(browserslist('ie<=9'), ['ie 9', 'ie 8']);
+});


### PR DESCRIPTION
I found myself trying `browserslist('>0% in dk')`, but that doesn't work even though `browserslist('>0%')` does. Took a stab at fixing that and ended up tightening up the regexps in other ways as well and being a bit more liberal with whitespace in general. I hope this aligns with the taste of the maintainers :)