### PR TITLE
Adding http://browserl.ist/ to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ For non-JS environment and debug purpose you can use CLI tool:
 browserslist "> 1%, last 2 version"
 ```
 
+To share browser support with users, you can use [browserl.ist](http://browserl.ist/).
+
 ## Coverage
 
 You can get total users coverage for selected browsers by JS API:


### PR DESCRIPTION
I created this site http://browserl.ist/ so I could use a browserslist query to show which browsers my company supports. I found this handy in our styleguide, where I wanted to share the info, but didn't want to have to update it every time a latest browser comes out.

Hopefully someone else will find it useful, so I added a blurb in the readme about it.

👋 Thanks 