### PR TITLE
Add section on targeting Electron.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ Names are case insensitive:
 The npm package [`electron-to-chromium`](https://www.npmjs.com/package/electron-to-chromium) exposes an `electronToBrowserList` API that you can use to get a compatible Browserslist query for your (major) Electron version:
 
 ```js
-    var e2c = require('electron-to-chromium');
-    var browserlistQuery - e2c.electronToBrowserList('1.4');
-    // browserlistQuery is 'Chrome >= 53'
+var e2c = require('electron-to-chromium');
+var browserlistQuery - e2c.electronToBrowserList('1.4');
+// browserlistQuery is 'Chrome >= 53'
 ```
     
 ## Config File

--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ Names are case insensitive:
 * `UCAndroid` or `and_uc` for UC Browser for Android.
 
 #### Electron
-The npm package [`electron-to-chromium`](https://www.npmjs.com/package/electron-to-chromium) exposes an electronToBrowserlist API that you can use to get a compatible BrowserList query for your (major) Electron version:
+The npm package [`electron-to-chromium`](https://www.npmjs.com/package/electron-to-chromium) exposes an `electronToBrowserList` API that you can use to get a compatible Browserslist query for your (major) Electron version:
 
 ```js
     var e2c = require('electron-to-chromium');
-    var browserlistQuery - e2c.electronToBrowserlist('1.4');
+    var browserlistQuery - e2c.electronToBrowserList('1.4');
     // browserlistQuery is 'Chrome >= 53'
 ```
     

--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ Names are case insensitive:
 * `Samsung` for Samsung Internet.
 * `UCAndroid` or `and_uc` for UC Browser for Android.
 
+#### Electron
+The npm package [`electron-to-chromium`](https://www.npmjs.com/package/electron-to-chromium) exposes an electronToBrowserlist API that you can use to get a compatible BrowserList query for your (major) Electron version:
+
+```js
+    var e2c = require('electron-to-chromium');
+    var browserlistQuery - e2c.electronToBrowserlist('1.4');
+    // browserlistQuery is 'Chrome >= 53'
+```
+    
 ## Config File
 
 Browserslist config should be named `browserslist` and have browsers queries


### PR DESCRIPTION
As mentioned in ticket #96, a short section on how to target Electron using BrowserList by utilising an external package to go from Electron version to valid BrowserList query string.