### PR TITLE
Reimplement `eachParent`'s traversal

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,12 +55,10 @@ function eachParent(file, callback) {
 
     if ( file === false ) return undefined;
     if ( typeof file === 'undefined' ) file = '.';
-
-    var dirs = path.resolve(file).split(path.sep);
-    while ( dirs.length ) {
-        var result = callback(dirs.join(path.sep));
+    var loc = path.resolve(file);
+    while (loc !== (loc = path.dirname(loc))) {
+        var result = callback(loc);
         if (typeof result !== 'undefined') return result;
-        dirs.pop();
     }
     return undefined;
 }


### PR DESCRIPTION
As discussed in #116.

Previously `eachParent` sliced the path all the way up to the empty string. Practically this meant that calls to `eachParent` ended up _also_ taking into consideration a `package.json` in the current working directory.

This implementation is based on [the traversal code in Babel](https://github.com/babel/babel/blob/master/packages/babel-core/src/transformation/file/options/build-config-chain.js#L60).