### PR TITLE
Restore eachParent traversal behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,10 +56,10 @@ function eachParent(file, callback) {
     if ( file === false ) return undefined;
     if ( typeof file === 'undefined' ) file = '.';
     var loc = path.resolve(file);
-    while (loc !== (loc = path.dirname(loc))) {
+    do {
         var result = callback(loc);
         if (typeof result !== 'undefined') return result;
-    }
+    } while (loc !== (loc = path.dirname(loc)));
     return undefined;
 }
 


### PR DESCRIPTION
The eachParent traversal modification in bc86e87e0e958e caused eachParent to skip the first iteration, as it were, compared to earlier behavior.

I.e. if you passed in `/foo/bar/quux`, 1.7.1 and before iterated over
 
* `/foo/bar/quux`
* `/foo/bar`
* `/foo`
* (erroneously) ``

1.7.2 and later (with the modification in bc86e87e0e958e) iterated over 

* `/foo/bar`
* `/foo`
* (correctly) `/`

given the same parameter.

This restores the 1.7.1 behavior, but with the `` bug corrected.