### PR TITLE
Don't use locale-aware comparison for browser names

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,6 +124,12 @@ function generateFilter(sign, version) {
     }
 }
 
+function compareStrings(a, b) {
+    if (a < b) return -1;
+    if (a > b) return +1;
+    return 0;
+}
+
 /**
  * Return array of browsers by selection queries.
  *
@@ -212,7 +218,6 @@ var browserslist = function (queries, opts) {
 
         error('Unknown browser query `' + selection + '`');
     });
-
     result = result.map(function (i) {
         var parts = i.split(' ');
         var name = parts[0];
@@ -229,10 +234,10 @@ var browserslist = function (queries, opts) {
             if ( FLOAT_RANGE.test(name1[1]) && FLOAT_RANGE.test(name2[1]) ) {
                 return parseFloat(name2[1]) - parseFloat(name1[1]);
             } else {
-                return name2[1].localeCompare(name1[1]);
+                return compareStrings(name2[1], name1[1]);
             }
         } else {
-            return name1[0].localeCompare(name2[0]);
+            return compareStrings(name1[0], name2[0]);
         }
     });
 


### PR DESCRIPTION
I used [`0x`](https://github.com/davidmarkclements/0x) to look at the flamegraphs for (you guessed it!) a CSS build, and found out a lot of time was spent sorting the browser list.

It might be a good idea to add an option to disable the sorting, since many use cases don't really need a prettily sorted list anyway?

Anyway, I don't think there's a good reason to use the collation-aware `String.localeCompare()` method for comparing browser names, which are always in ASCII.

## Performance impact

Using this highly synthetic benchmark which simply calls the `browserlist()` function 10,000 times, this branch is **28% faster** than 1.7.3.

```shell
$ time node -e 'bl=require(".");for(i=0;i<10000;i++){bl([">1%"])}'
```
* `master` (19b3610): 1.44 seconds
* `no-locale-compare`: (196c739): 1.12 seconds