### PR TITLE
Support "all" queries

### DIFF
--- a/index.js
+++ b/index.js
@@ -619,6 +619,27 @@ browserslist.queries = {
         }
     },
 
+    all: {
+        regexp: /^all(?:\s+(\w+)\s*)?$/i,
+        select: function (context, name) {
+            if (name) {
+                var optdata = browserslist.checkName(name);
+
+                return optdata.released.map(function (v) {
+                    return optdata.name + ' ' + v;
+                });
+            } else {
+                return Object.keys(caniuse).reduce(function (all, eachname) {
+                    var eachdata = browserslist.byName(eachname);
+                    if ( !eachdata ) return all;
+                    return all.concat(eachdata.released.map(function (v) {
+                        return eachdata.name + ' ' + v;
+                    }));
+                }, []);
+            }
+        }
+    },
+
     esr: {
         regexp: /^(firefox|ff|fx)\s+esr$/i,
         select: function () {

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -4,6 +4,11 @@ var originData = browserslist.data;
 
 beforeEach(() => {
     browserslist.data = {
+        edge: {
+            name:     'edge',
+            released: ['12', '13', '14', '15'],
+            versions: ['12', '13', '14', '15']
+        },
         ie: {
             name:     'ie',
             released: ['9', '10', '11'],
@@ -14,6 +19,16 @@ beforeEach(() => {
 
 afterEach(() => {
     browserslist.data = originData;
+});
+
+it('selects all versions of browser', () => {
+    expect(browserslist('all ie')).toEqual(['ie 11', 'ie 10', 'ie 9']);
+});
+
+it('selects all versions of all browsers', () => {
+    expect(browserslist('all')).toEqual([
+        'edge 15', 'edge 14', 'edge 13', 'edge 12', 'ie 11', 'ie 10', 'ie 9'
+    ]);
 });
 
 it('selects versions of browser', () => {


### PR DESCRIPTION
Adds support for queries like `all ie`, `all ff`, and even `all`

Resolves #151