### PR TITLE
Fix `TypeError: Path must be a string. Received undefined`

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ function getStat (opts) {
   } else if (process.env.BROWSERSLIST_STATS) {
     return process.env.BROWSERSLIST_STATS
   } else {
-    return eachParent(opts.path, function (dir) {
+    return opts.path && eachParent(opts.path, function (dir) {
       var file = path.join(dir, 'browserslist-stats.json')
       return isFile(file) ? file : undefined
     })


### PR DESCRIPTION
After 9d3e5de995a5f560452c6f9457f41e25b5634924 I was getting `TypeError: Path must be a string. Received undefined`.

Fixes #158 