### PR TITLE
Fix 'TypeError: Path must be a string'

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,12 +75,12 @@ function getStat (opts) {
     return opts.stats
   } else if (process.env.BROWSERSLIST_STATS) {
     return process.env.BROWSERSLIST_STATS
-  } else {
+  } else if (opts.path) {
     return eachParent(opts.path, function (dir) {
       var file = path.join(dir, 'browserslist-stats.json')
       return isFile(file) ? file : undefined
     })
-  }
+  } else return undefined
 }
 
 function parsePackage (file) {


### PR DESCRIPTION
This fixes an issue reported here - stylelint/stylelint/#2775.
Credit goes to @silverwind for pointing me in the right direction:
> I think this maybe because of this line:
https://github.com/ai/browserslist/commit/9d3e5de995a5f560452c6f9457f41e25b5634924#diff-168726dbe96b3ce427e7fedce31bb0bcR81

The issue was that in the refactoring, an `if` condition checking that `opts.path` existed was missed. And `path` module does not take kindly to being asked to resolve `undefined` values.

I used `npm link` to test this with stylelint and all test cases which were failing before are now okay.
No tests are failing in browserslist either:
```
Test Suites: 18 passed, 18 total
Tests:       120 passed, 120 total
Snapshots:   0 total
Time:        22.577s
Ran all test suites.
----------|----------|----------|----------|----------|----------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------|----------|----------|----------|----------|----------------|
All files |    99.71 |    93.72 |      100 |     99.7 |                |
 index.js |    99.71 |    93.72 |      100 |     99.7 |             83 |
----------|----------|----------|----------|----------|----------------|
Jest: Coverage for statements (99.71%) does not meet global threshold (100%)
error Command failed with exit code 1.
```
If someone could give me some hint on where the test case needs to be added, I can. However, it might be more important to push out this fix as it completely breaks stylelint.

cc @davidtheclark Looks like we aren't the only ones breaking stylelint inadvertently.