### PR TITLE
Resolve `Path must be a string` error

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,12 +75,14 @@ function getStat (opts) {
     return opts.stats
   } else if (process.env.BROWSERSLIST_STATS) {
     return process.env.BROWSERSLIST_STATS
-  } else {
+  } else if (opts.path) {
     return eachParent(opts.path, function (dir) {
       var file = path.join(dir, 'browserslist-stats.json')
       return isFile(file) ? file : undefined
     })
   }
+
+  return undefined
 }
 
 function parsePackage (file) {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -55,6 +55,11 @@ it('reads config by direct path in environment variable', () => {
   expect(browserslist(null, { path: FILE })).toEqual(['ie 9', 'ie 8'])
 })
 
+it('handles undefined stats and path correctly', () => {
+  var config = { stats: undefined, path: undefined }
+  expect(browserslist([], config)).toEqual([])
+})
+
 it('throw a error on wrong path to config', () => {
   expect(() => {
     browserslist(null, { config: IE + '2' })


### PR DESCRIPTION
Fixes #158 

Included a quick & dirty test that fails in 2.2.1 but works with this change.