### PR TITLE
Fix version detecting

### DIFF
--- a/index.js
+++ b/index.js
@@ -641,7 +641,7 @@ var QUERIES = [
     regexp: /^(\w+)\s*(>=?|<=?)\s*([\d.]+)$/,
     select: function (context, name, sign, version) {
       var data = checkName(name)
-      var alias = normalizeVersion(data, version)
+      var alias = browserslist.versionAliases[data.name][version]
       if (alias) {
         version = alias
       }


### PR DESCRIPTION
This bug (#166) occurs if browser has only one version.

So, when the browser have only one version and `normalizeVersion` got `0` (or another non-existent version), it returns normalized version, eg. `56`. Eventually, `generateFilter` compares `56` with `56` instead of `0`.

In this case we should not normalize version, we just should detect if version alias is exist.