### PR TITLE
New Feature: Major versions queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ We recommend to write queries in `package.json`.
 You can specify the versions by queries (case insensitive):
 
 * `last 2 versions`: the last 2 versions for each browser.
+* `last 2 major versions`: all minor/patch releases of the current and previous major versions
 * `last 2 Chrome versions`: the last 2 versions of Chrome browser.
+* `last 2 iOS major versions`: all minor/patch releases of the current and previous major versions of iOS Safari
 * `> 5%` or `>= 5%`: versions selected by global usage statistics.
 * `> 5% in US`: uses USA usage statistics. It accepts [two-letter country code].
 * `> 5% in alt-AS`: uses Asia region usage statistics. List of all region codes

--- a/test/last.major.test.js
+++ b/test/last.major.test.js
@@ -1,0 +1,69 @@
+var browserslist = require('../')
+
+var originData = browserslist.data
+
+beforeEach(() => {
+  browserslist.data = {
+    ie: {
+      name: 'ie',
+      released: ['9', '10', '11'],
+      versions: ['9', '10', '11']
+    },
+    edge: {
+      name: 'edge',
+      released: ['8', '9', '10', '11.0.1', '11.1', '12'],
+      versions: ['8', '9', '10', '11.0.1', '11.1', '12', '13']
+    },
+    chrome: {
+      name: 'chrome',
+      released: ['37', '38', '39'],
+      versions: ['37', '38', '39', '40']
+    },
+    bb: {
+      name: 'bb',
+      released: ['8', '10'],
+      versions: ['8']
+    },
+    firefox: {
+      released: []
+    }
+  }
+})
+
+afterEach(() => {
+  browserslist.data = originData
+})
+
+it('selects versions of each browser', () => {
+  expect(browserslist('last 2 major versions')).toEqual([
+    'bb 10',
+    'chrome 39',
+    'chrome 38',
+    'edge 12',
+    'edge 11.1',
+    'edge 11.0.1',
+    'ie 11',
+    'ie 10'
+  ])
+})
+
+it('supports pluralization', () => {
+  expect(browserslist('last 1 major version'))
+    .toEqual(['bb 10', 'chrome 39', 'edge 12', 'ie 11'])
+})
+
+it('is case insensitive', () => {
+  expect(browserslist('Last 01 MaJoR Version'))
+    .toEqual(['bb 10', 'chrome 39', 'edge 12', 'ie 11'])
+})
+
+it('selects versions of a single browser', () => {
+  expect(browserslist('last 2 edge major versions'))
+    .toEqual(['edge 12', 'edge 11.1', 'edge 11.0.1'])
+
+  expect(browserslist('last 1 bb major version'))
+    .toEqual(['bb 10'])
+
+  expect(browserslist('last 3 Chrome major versions'))
+    .toEqual(['chrome 39', 'chrome 38', 'chrome 37'])
+})


### PR DESCRIPTION
**Feature:**
Fixes: https://github.com/ai/browserslist/issues/169

Add two new query types which allow users to specify which major versions of a browser/all browsers to allow.  Examples:

* `last 2 major versions`: all minor/patch releases of the current and previous major versions
* `last 2 iOS major versions`: all minor/patch releases of the current and previous major versions of iOS Safari

**Changes:**
- Added a `getLastMajorVersions` utility function for filtering the released versions of a browser to only include the last two major versions.
- Added and used a `curryMapName` utility method to keep the file size down.  There were plenty of select functions that ended by mapping over the resulting version numbers to prefix them with the browser name.  `curryMapName` accepts the browser name and curries a function which can be passed to `Array.prototype.map` in order to do the prefixing.
- Tests
- README update

cc: @ai