### PR TITLE
Clarify comment about babel-preset-env external config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Library to share supported browsers list between different front-end tools.
 It is used in:
 
 * [Autoprefixer]
-* [babel-preset-env] (no config support, only tool option)
+* [babel-preset-env]
+  (external config in package.json or browserslist files supported in v2.0+)
 * [eslint-plugin-compat]
 * [stylelint-no-unsupported-browser-features]
 * [postcss-normalize]


### PR DESCRIPTION
I was reading the README and I noticed [this line](https://github.com/ai/browserslist/blame/3da9c02fee368f1aed10b9b6fd905f558f64ffe8/README.md#L10):
https://github.com/ai/browserslist/blob/3da9c02fee368f1aed10b9b6fd905f558f64ffe8/README.md#L10

The "no config support, only tool option" comment confused me, because if you follow the link to the babel-preset-env repository, you will find [documentation about support for external config in package.json or browserlist files](https://github.com/babel/babel-preset-env/blame/927a3b521907fce260898208a3d30c1694917730/README.md#L108-L149).

That's because the master branch of the babel-preset-env repository is for version 2.0, while the README for the latest 1.x release is only available on the [1.x branch](https://github.com/babel/babel-preset-env/tree/1.x).

Version 2.0 is currently still in beta, but it includes support for reading an external config in package.json or browserslist files (via https://github.com/babel/babel-preset-env/pull/161).

With this in mind, I've updated this comment to:
> external config in package.json or browserslist files supported in v2.0+

in an effort to remove this confusion. Once version 2.0 gets out of beta, we can probably remove this comment, but until then I think it's helpful, and lets users know that if they want external config support they can try the latest beta release of babel-present-env v2.0.