### PR TITLE
Add support for @scope/browserslist-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,12 @@ from another package:
 ```
 
 For security reasons, external configuration only supports packages that have
-the `browserslist-config-` prefix. If you doesn’t accept Browserslist queries
-from users, you can disable the validation by `dangerousExtend` option:
+the `browserslist-config-` prefix. npm scoped packages are also supported, by
+naming or prefixing the module with `@scope/browserslist-config`, such as
+`@scope/browserslist-config` or `@scope/browserslist-config-mycompany`.
+
+If you don't accept Browserslist queries from users, you can disable the
+validation by using the `dangerousExtend` option:
 
 ```js
 browserslist(queries, { path, dangerousExtend: true })

--- a/index.js
+++ b/index.js
@@ -764,7 +764,7 @@ var QUERIES = [
 ]
 
 var CONFIG_PATTERN = /^browserslist-config-/
-var SCOPED_CONFIG__PATTERN = /@[^./]+\/browserslist-config-/
+var SCOPED_CONFIG__PATTERN = /@[^./]+\/browserslist-config(-|$)/
 
 function checkExtend (name) {
   var use = ' Use `dangerousExtend` option to disable.'

--- a/test/extends.test.js
+++ b/test/extends.test.js
@@ -28,6 +28,12 @@ it('handles scoped packages', () => {
   expect(result).toEqual(['ie 11'])
 })
 
+it('handles scoped packages when package is @scope/browserslist-config', () => {
+  mock('@scope/browserslist-config', ['ie 11'])
+  var result = browserslist(['extends @scope/browserslist-config'])
+  expect(result).toEqual(['ie 11'])
+})
+
 it('recursively imports configs', () => {
   mock('browserslist-config-one', ['extends browserslist-config-two', 'ie 9'])
   mock('browserslist-config-two', ['ie 10'])


### PR DESCRIPTION
This PR adds in support for handling `@scope/browserslist-config` as the package name for a shared configuration.

Currently, it only handles checking for the `@scope/browserslist-config-*` prefix.