### PR TITLE
New "since" query

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ You can specify the versions by queries (case insensitive):
 * `unreleased versions`: alpha and beta versions of each browser.
 * `unreleased Chrome versions`: alpha and beta versions of Chrome browser.
 * `not ie <= 8`: exclude browsers selected before by previous queries.
+* `since 2013`: all versions released since year 2013
   You can add `not ` to any query.
 
 Browserslist works with separated versions of browsers.

--- a/index.js
+++ b/index.js
@@ -559,15 +559,15 @@ var QUERIES = [
   {
     regexp: /^since (\d+)$/i,
     select: function (context, year) {
-      var ts = new Date(parseInt(year), 0, 1, 0, 0, 0)
-      if (ts > Date.now()) throw new BrowserslistError('Incorrect year')
-      ts /= 1000
+      var since = new Date(parseInt(year), 0, 1, 0, 0, 0)
+      if (since > Date.now()) throw new BrowserslistError('Incorrect year')
+      since /= 1000
 
       return Object.keys(agents).reduce(function (selected, name) {
         var data = byName(name)
         if (!data) return selected
         var versions = Object.keys(data.releaseDate).filter(function (v) {
-          return data.releaseDate[v] > ts
+          return data.releaseDate[v] > since
         })
         return selected.concat(versions.map(nameMapper(data.name)))
       }, [])

--- a/index.js
+++ b/index.js
@@ -563,6 +563,23 @@ var QUERIES = [
     }
   },
   {
+    regexp: /^since (\d+)$/i,
+    select: function (context, year) {
+      var ts = new Date(parseInt(year), 0, 1, 0, 0, 0)
+      if (ts > Date.now()) throw new BrowserslistError('Incorrect year')
+      ts /= 1000
+
+      return Object.keys(agents).reduce(function (selected, name) {
+        var data = byName(name)
+        if (!data) return selected
+        var versions = Object.keys(data.releaseDate).filter(function (v) {
+          return data.releaseDate[v] > ts
+        })
+        return selected.concat(versions.map(nameMapper(data.name)))
+      }, [])
+    }
+  },
+  {
     regexp: /^(>=?)\s*(\d*\.?\d+)%$/,
     select: function (context, sign, popularity) {
       popularity = parseFloat(popularity)
@@ -789,7 +806,8 @@ function checkExtend (name) {
     browserslist.data[name] = {
       name: name,
       versions: normalize(agents[name].versions),
-      released: normalize(agents[name].versions.slice(0, -3))
+      released: normalize(agents[name].versions.slice(0, -3)),
+      releaseDate: agents[name].release_date
     }
     fillUsage(browserslist.usage.global, name, browser.usage_global)
 

--- a/index.js
+++ b/index.js
@@ -494,31 +494,27 @@ var QUERIES = [
   {
     regexp: /^last\s+(\d+)\s+major versions?$/i,
     select: function (context, versions) {
-      var selected = []
-      Object.keys(agents).forEach(function (name) {
+      return Object.keys(agents).reduce(function (selected, name) {
         var data = byName(name)
-        if (!data) return
+        if (!data) return selected
         var array = getMajorVersions(data.released, versions)
 
         array = array.map(nameMapper(data.name))
-        selected = selected.concat(array)
-      })
-      return selected
+        return selected.concat(array)
+      }, [])
     }
   },
   {
     regexp: /^last\s+(\d+)\s+versions?$/i,
     select: function (context, versions) {
-      var selected = []
-      Object.keys(agents).forEach(function (name) {
+      return Object.keys(agents).reduce(function (selected, name) {
         var data = byName(name)
-        if (!data) return
+        if (!data) return selected
         var array = data.released.slice(-versions)
 
         array = array.map(nameMapper(data.name))
-        selected = selected.concat(array)
-      })
-      return selected
+        return selected.concat(array)
+      }, [])
     }
   },
   {
@@ -539,18 +535,16 @@ var QUERIES = [
   {
     regexp: /^unreleased\s+versions$/i,
     select: function () {
-      var selected = []
-      Object.keys(agents).forEach(function (name) {
+      return Object.keys(agents).reduce(function (selected, name) {
         var data = byName(name)
-        if (!data) return
+        if (!data) return selected
         var array = data.versions.filter(function (v) {
           return data.released.indexOf(v) === -1
         })
 
         array = array.map(nameMapper(data.name))
-        selected = selected.concat(array)
-      })
-      return selected
+        return selected.concat(array)
+      }, [])
     }
   },
   {
@@ -583,49 +577,47 @@ var QUERIES = [
     regexp: /^(>=?)\s*(\d*\.?\d+)%$/,
     select: function (context, sign, popularity) {
       popularity = parseFloat(popularity)
-      var result = []
+      var usage = browserslist.usage.global
 
-      for (var version in browserslist.usage.global) {
+      return Object.keys(usage).reduce(function (result, version) {
         if (sign === '>') {
-          if (browserslist.usage.global[version] > popularity) {
+          if (usage[version] > popularity) {
             result.push(version)
           }
-        } else if (browserslist.usage.global[version] >= popularity) {
+        } else if (usage[version] >= popularity) {
           result.push(version)
         }
-      }
-
-      return result
+        return result
+      }, [])
     }
   },
   {
     regexp: /^(>=?)\s*(\d*\.?\d+)%\s+in\s+my\s+stats$/,
     select: function (context, sign, popularity) {
       popularity = parseFloat(popularity)
-      var result = []
 
       if (!context.customUsage) {
         throw new BrowserslistError('Custom usage statistics was not provided')
       }
 
-      for (var version in context.customUsage) {
+      var usage = context.customUsage
+
+      return Object.keys(usage).reduce(function (result, version) {
         if (sign === '>') {
-          if (context.customUsage[version] > popularity) {
+          if (usage[version] > popularity) {
             result.push(version)
           }
-        } else if (context.customUsage[version] >= popularity) {
+        } else if (usage[version] >= popularity) {
           result.push(version)
         }
-      }
-
-      return result
+        return result
+      }, [])
     }
   },
   {
     regexp: /^(>=?)\s*(\d*\.?\d+)%\s+in\s+((alt-)?\w\w)$/,
     select: function (context, sign, popularity, place) {
       popularity = parseFloat(popularity)
-      var result = []
 
       if (place.length === 2) {
         place = place.toUpperCase()
@@ -636,7 +628,7 @@ var QUERIES = [
       loadCountryStatistics(place)
       var usage = browserslist.usage[place]
 
-      for (var version in usage) {
+      return Object.keys(usage).reduce(function (result, version) {
         if (sign === '>') {
           if (usage[version] > popularity) {
             result.push(version)
@@ -644,9 +636,8 @@ var QUERIES = [
         } else if (usage[version] >= popularity) {
           result.push(version)
         }
-      }
-
-      return result
+        return result
+      }, [])
     }
   },
   {

--- a/index.js
+++ b/index.js
@@ -559,9 +559,7 @@ var QUERIES = [
   {
     regexp: /^since (\d+)$/i,
     select: function (context, year) {
-      var since = new Date(parseInt(year), 0, 1, 0, 0, 0)
-      if (since > Date.now()) throw new BrowserslistError('Incorrect year')
-      since /= 1000
+      var since = new Date(parseInt(year), 0, 1, 0, 0, 0) / 1000
 
       return Object.keys(agents).reduce(function (selected, name) {
         var data = byName(name)

--- a/test/since.test.js
+++ b/test/since.test.js
@@ -1,0 +1,67 @@
+var browserslist = require('../')
+
+var originData = browserslist.data
+
+beforeEach(() => {
+  browserslist.data = {
+    ie: {
+      name: 'ie',
+      versions: ['5.5', '6', '7', '8', '9', '10', '11'],
+      releaseDate: {
+        '6': 998870400,
+        '7': 1161129600,
+        '8': 1237420800,
+        '9': 1300060800,
+        '10': 1346716800,
+        '11': 1381968000,
+        '5.5': 962323200
+      }
+    },
+    safari: {
+      name: 'safari',
+      versions: [
+        '3.1', '3.2', '4', '5', '5.1', '6', '6.1', '7', '7.1', '8', '9', '9.1',
+        '10', '10.1', '11', 'TP'
+      ],
+      releaseDate: {
+        '4': 1244419200,
+        '5': 1275868800,
+        '6': 1343174400,
+        '7': 1382400000,
+        '8': 1413417600,
+        '9': 1443657600,
+        '10': 1474329600,
+        '11': 1505779200,
+        '3.1': 1205798400,
+        '3.2': 1226534400,
+        '5.1': 1311120000,
+        '6.1': 1382400000,
+        '7.1': 1410998400,
+        '9.1': 1458518400,
+        '10.1': 1490572800,
+        TP: null
+      }
+    }
+  }
+})
+
+afterEach(() => {
+  browserslist.data = originData
+})
+
+it('selects versions released since specified year', () => {
+  expect(browserslist('since 2013'))
+    .toEqual([
+      'ie 11', 'safari 11', 'safari 10.1', 'safari 10', 'safari 9.1',
+      'safari 9', 'safari 8', 'safari 7.1', 'safari 7', 'safari 6.1'
+    ])
+})
+
+it('is case insensitive', () => {
+  expect(browserslist('sInCe 2016'))
+    .toEqual(['safari 11', 'safari 10.1', 'safari 10', 'safari 9.1'])
+})
+
+it('throws error on incorrect year', () => {
+  expect(() => browserslist('since 9999')).toThrow()
+})

--- a/test/since.test.js
+++ b/test/since.test.js
@@ -61,7 +61,3 @@ it('is case insensitive', () => {
   expect(browserslist('sInCe 2016'))
     .toEqual(['safari 11', 'safari 10.1', 'safari 10', 'safari 9.1'])
 })
-
-it('throws error on incorrect year', () => {
-  expect(() => browserslist('since 9999')).toThrow()
-})


### PR DESCRIPTION
Hi! This adds the new `since <year>` query to target all versions released since the year specified.
This PR relies on changes made in ben-eb/caniuse-lite#11.

P.S. Also, will it be useful to as well add similar `until` rule for browser versions released *until* certain year? May be useful for legacy environments. 

#145