### PR TITLE
Add support for "last electron versions" and "last electron major versions"

### DIFF
--- a/index.js
+++ b/index.js
@@ -517,11 +517,28 @@ var QUERIES = [
     }
   },
   {
+    regexp: /^last\s+(\d+)\s+electron\s+major versions?$/i,
+    select: function (context, versions) {
+      var validVersions = getMajorVersions(Object.keys(e2c).reverse(), versions)
+      return validVersions.map(function (i) {
+        return 'chrome ' + e2c[i]
+      })
+    }
+  },
+  {
     regexp: /^last\s+(\d+)\s+(\w+)\s+major versions?$/i,
     select: function (context, versions, name) {
       var data = checkName(name)
       var validVersions = getMajorVersions(data.released, versions)
       return validVersions.map(nameMapper(data.name))
+    }
+  },
+  {
+    regexp: /^last\s+(\d+)\s+electron\s+versions?$/i,
+    select: function (context, versions) {
+      return Object.keys(e2c).reverse().slice(-versions).map(function (i) {
+        return 'chrome ' + e2c[i]
+      })
     }
   },
   {
@@ -544,6 +561,16 @@ var QUERIES = [
         array = array.map(nameMapper(data.name))
         return selected.concat(array)
       }, [])
+    }
+  },
+  {
+    regexp: /^unreleased\s+electron\s+versions?$/i,
+    select: function () {
+      return Object.keys(e2c).filter(function (v) {
+        return Object.keys(e2c).indexOf(v) === -1
+      }).reverse().map(function (i) {
+        return 'chrome ' + e2c[i]
+      })
     }
   },
   {


### PR DESCRIPTION
I didn't add tests for latest versions of Electron because it depends on [electron-to-chromium](https://github.com/Kilian/electron-to-chromium). If tests are needed, consider making the e2c variable a property of the browserslist object, and then overwrite it.
I could have replace the entire **unreleased** function by a 
```js
return []
```
but it seemed cleaner this way.