### PR TITLE
Support '< 1%' (useful for 'not' queries)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ You can specify the versions by queries (case insensitive):
   `browserslist-config-mycompany` npm package.
 * `unreleased versions`: alpha and beta versions of each browser.
 * `unreleased Chrome versions`: alpha and beta versions of Chrome browser.
-* `not ie <= 8`: exclude browsers selected before by previous queries.
+* `not ie <= 8`: exclude browsers selected by previous queries (by browser version).
+* `not < 1%`: exclude browsers selected by previous queries (by browser usage).
 * `since 2013`: all versions released since year 2013
   (also `since 2013-03` and `since 2013-03-10`).
 

--- a/index.js
+++ b/index.js
@@ -598,7 +598,7 @@ var QUERIES = [
     }
   },
   {
-    regexp: /^(>=?)\s*(\d*\.?\d+)%$/,
+    regexp: /^(>=?|<=?)\s*(\d*\.?\d+)%$/,
     select: function (context, sign, popularity) {
       popularity = parseFloat(popularity)
       var usage = browserslist.usage.global
@@ -606,6 +606,14 @@ var QUERIES = [
       return Object.keys(usage).reduce(function (result, version) {
         if (sign === '>') {
           if (usage[version] > popularity) {
+            result.push(version)
+          }
+        } else if (sign === '<') {
+          if (usage[version] < popularity) {
+            result.push(version)
+          }
+        } else if (sign === '<=') {
+          if (usage[version] <= popularity) {
             result.push(version)
           }
         } else if (usage[version] >= popularity) {
@@ -616,7 +624,7 @@ var QUERIES = [
     }
   },
   {
-    regexp: /^(>=?)\s*(\d*\.?\d+)%\s+in\s+my\s+stats$/,
+    regexp: /^(>=?|<=?)\s*(\d*\.?\d+)%\s+in\s+my\s+stats$/,
     select: function (context, sign, popularity) {
       popularity = parseFloat(popularity)
 
@@ -631,6 +639,14 @@ var QUERIES = [
           if (usage[version] > popularity) {
             result.push(version)
           }
+        } else if (sign === '<') {
+          if (usage[version] < popularity) {
+            result.push(version)
+          }
+        } else if (sign === '<=') {
+          if (usage[version] <= popularity) {
+            result.push(version)
+          }
         } else if (usage[version] >= popularity) {
           result.push(version)
         }
@@ -639,7 +655,7 @@ var QUERIES = [
     }
   },
   {
-    regexp: /^(>=?)\s*(\d*\.?\d+)%\s+in\s+((alt-)?\w\w)$/,
+    regexp: /^(>=?|<=?)\s*(\d*\.?\d+)%\s+in\s+((alt-)?\w\w)$/,
     select: function (context, sign, popularity, place) {
       popularity = parseFloat(popularity)
 
@@ -655,6 +671,14 @@ var QUERIES = [
       return Object.keys(usage).reduce(function (result, version) {
         if (sign === '>') {
           if (usage[version] > popularity) {
+            result.push(version)
+          }
+        } else if (sign === '<') {
+          if (usage[version] < popularity) {
+            result.push(version)
+          }
+        } else if (sign === '<=') {
+          if (usage[version] <= popularity) {
             result.push(version)
           }
         } else if (usage[version] >= popularity) {

--- a/test/country.test.js
+++ b/test/country.test.js
@@ -25,6 +25,14 @@ it('selects popularity by more or equal', () => {
   expect(browserslist('>= 5% in US')).toEqual(['ie 11', 'ie 10', 'ie 9'])
 })
 
+it('selects browsers by unpopularity', () => {
+  expect(browserslist('< 5% in US')).toEqual(['ie 8'])
+})
+
+it('selects unpopularity by less or equal', () => {
+  expect(browserslist('<= 5% in US')).toEqual(['ie 9', 'ie 8'])
+})
+
 it('works with float', () => {
   expect(browserslist('> 10.2% in US')).toEqual(['ie 11'])
 })

--- a/test/custom.test.js
+++ b/test/custom.test.js
@@ -31,6 +31,16 @@ it('selects popularity by more or equal', () => {
     .toEqual(['ie 11', 'ie 10'])
 })
 
+it('selects browsers by unpopularity', () => {
+  expect(browserslist('< 0.5% in my stats', { stats: CUSTOM_STATS }))
+    .toEqual(['chrome 34', 'ie 8'])
+})
+
+it('selects unpopularity by less or equal', () => {
+  expect(browserslist('<= 2.3% in my stats', { stats: CUSTOM_STATS }))
+    .toEqual(['chrome 36', 'chrome 35', 'chrome 34', 'ie 9', 'ie 8'])
+})
+
 it('accepts non-space query', () => {
   expect(browserslist('>10% in my stats', { stats: CUSTOM_STATS }))
     .toEqual(['ie 11'])

--- a/test/global.test.js
+++ b/test/global.test.js
@@ -25,6 +25,14 @@ it('selects popularity by more or equal', () => {
   expect(browserslist('>= 5%')).toEqual(['ie 11', 'ie 10', 'ie 9'])
 })
 
+it('selects browsers by unpopularity', () => {
+  expect(browserslist('< 5%')).toEqual(['ie 8'])
+})
+
+it('selects unpopularity by less or equal', () => {
+  expect(browserslist('<= 5%')).toEqual(['ie 9', 'ie 8'])
+})
+
 it('accepts non-space query', () => {
   expect(browserslist('>10%')).toEqual(['ie 11', 'ie 10'])
 })


### PR DESCRIPTION
The ability to exclude by % usage in `not` queries felt like a missed opportunity. 🤓 

_Cheers!_ 🍻 

----

### December 5th, 2017 (example queries)

**'defaults'**
```
and_chr 62
and_ff 57
and_qq 1.2
and_uc 11.4
android 62
android 4.4.3-4.4.4
baidu 7.12
bb 10
bb 7
chrome 62
chrome 61
chrome 60
edge 16
edge 15
firefox 57
firefox 56
firefox 52
ie 11
ie 10
ie_mob 11
ie_mob 10
ios_saf 11
ios_saf 10.3
op_mini all
op_mob 37
op_mob 12.1
opera 48
opera 47
safari 11
safari 10.1
samsung 5
samsung 4
```
**'>= 0.7%'**
```
and_chr 62
and_uc 11.4
android 4.4
chrome 62
chrome 61
chrome 60
chrome 49
edge 15
firefox 56
ie 11
ios_saf 11
ios_saf 10.3
ios_saf 10.0-10.2
op_mini all
opera 48
safari 11
samsung 5
samsung 4
```
**'defaults, not < 0.7%'**
```
and_chr 62
and_uc 11.4
chrome 62
chrome 61
chrome 60
edge 15
firefox 56
ie 11
ios_saf 11
ios_saf 10.3
op_mini all
opera 48
safari 11
samsung 5
samsung 4
```
**'since 2016, not < 1%'**
```
and_chr 62
and_uc 11.4
chrome 61
chrome 60
edge 15
firefox 56
ios_saf 11
ios_saf 10.3
safari 11
samsung 5
samsung 4
```