### PR TITLE
For easier use in the browser, add simple guard against undefined process global

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function getMajorVersions (released, number) {
   return selected
 }
 
-var env = process.env
+var env = typeof process === 'undefined' ? {} : process.env
 
 var FLOAT_RANGE = /^\d+(\.\d+)?(-\d+(\.\d+)?)*$/
 var IS_SECTION = /^\s*\[(.+)\]\s*$/


### PR DESCRIPTION
When using browserslist with webpack and targeting the browser, users need to add
```js
new webpack.DefinePlugin({ 'process.env': {} }),
```
to their webpack config in addition to more idiomatic `DefinePlugin` uses (e.g. `new webpack.DefinePlugin({ 'process.env.NODE_ENV': JSON.stringify('production') })`).

This PR adds a very simple `typeof` test on the `process` global with a default value to avoid the need for that extra unintuitive bit of config.