### PR TITLE
Support 'last 2 years' query

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ You can specify the versions by queries (case insensitive):
 
 * `last 2 versions`: the last 2 versions for each browser.
 * `last 2 Chrome versions`: the last 2 versions of Chrome browser.
+* `last 2 years`: all versions released in the last 2 years
 * `> 5%`: versions selected by global usage statistics.
   `>=`, `<` and `<=` work too.
 * `> 5% in US`: uses USA usage statistics. It accepts [two-letter country code].

--- a/index.js
+++ b/index.js
@@ -322,6 +322,17 @@ function loadCountryStatistics (country) {
   }
 }
 
+function filterByYear (since) {
+  return Object.keys(agents).reduce(function (selected, name) {
+    var data = byName(name)
+    if (!data) return selected
+    var versions = Object.keys(data.releaseDate).filter(function (v) {
+      return data.releaseDate[v] >= since
+    })
+    return selected.concat(versions.map(nameMapper(data.name)))
+  }, [])
+}
+
 // Will be filled by Can I Use data below
 browserslist.data = { }
 browserslist.usage = {
@@ -581,6 +592,15 @@ var QUERIES = [
     }
   },
   {
+    regexp: /^last\s+(\d+)\s+years?$/i,
+    select: function (context, years) {
+      var date = new Date()
+      var since = date.setFullYear(date.getFullYear() - years) / 1000
+
+      return filterByYear(since)
+    }
+  },
+  {
     regexp: /^since (\d+)(?:-(\d+))?(?:-(\d+))?$/i,
     select: function (context, year, month, date) {
       year = parseInt(year)
@@ -588,14 +608,7 @@ var QUERIES = [
       date = parseInt(date || '01')
       var since = Date.UTC(year, month, date, 0, 0, 0) / 1000
 
-      return Object.keys(agents).reduce(function (selected, name) {
-        var data = byName(name)
-        if (!data) return selected
-        var versions = Object.keys(data.releaseDate).filter(function (v) {
-          return data.releaseDate[v] >= since
-        })
-        return selected.concat(versions.map(nameMapper(data.name)))
-      }, [])
+      return filterByYear(since)
     }
   },
   {

--- a/test/lastYears.test.js
+++ b/test/lastYears.test.js
@@ -1,0 +1,52 @@
+var browserslist = require('../')
+
+var RealDate = Date
+var originData = browserslist.data
+
+function mockDate (iso) {
+  global.Date = function () {
+    Object.getPrototypeOf(RealDate.prototype).constructor.call(this)
+    return new RealDate(iso)
+  }
+}
+
+beforeEach(() => {
+  mockDate('2018-01-01T00:00:00z')
+  browserslist.data = {
+    ie: {
+      name: 'ie',
+      released: ['9', '10', '11'],
+      releaseDate: {
+        '9': 1300060800, // 2011-03-14T00:00:00.000Z
+        '10': 1346716800, // 2012-09-04T00:00:00.000Z
+        '11': 1381968000 // 2013-10-17T00:00:00.000Z
+      }
+    },
+    edge: {
+      name: 'edge',
+      released: ['12', '13', '14', '15', '16'],
+      releaseDate: {
+        '12': 1438128000, // 2015-07-29T00:00:00.000Z
+        '13': 1447286400, // 2015-11-12T00:00:00.000Z
+        '14': 1470096000, // 2016-08-02T00:00:00.000Z
+        '15': 1491868800, // 2017-04-11T00:00:00.000Z
+        '16': 1508198400 // 2017-10-17T00:00:00.000Z
+      }
+    }
+  }
+})
+
+afterEach(() => {
+  global.Date = RealDate
+  browserslist.data = originData
+})
+
+it('selects versions released within last X years', () => {
+  expect(browserslist('last 2 years'))
+    .toEqual(['edge 16', 'edge 15', 'edge 14'])
+})
+
+it('is case insensitive', () => {
+  expect(browserslist('Last 5 years'))
+    .toEqual(['edge 16', 'edge 15', 'edge 14', 'edge 13', 'edge 12', 'ie 11'])
+})


### PR DESCRIPTION
Expanding upon https://github.com/ai/browserslist/pull/189, this PR adds support for relative year queries with `last <number> years` to target all versions released within `<number>` amount of years. E.g [`last 3 years, not < 1%`](http://browserl.ist/?q=since+2016%2C+not+%3C+1%25)

Closes #208 