### PR TITLE
upgrade electron-to-chromium

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "repository": "ai/browserslist",
   "dependencies": {
     "caniuse-lite": "^1.0.30000792",
-    "electron-to-chromium": "^1.3.30"
+    "electron-to-chromium": "^1.3.31"
   },
   "bin": "./cli.js",
   "devDependencies": {


### PR DESCRIPTION
Minor version upgrade of [electron-to-chromium](https://www.npmjs.com/package/electron-to-chromium).

This version contains this [PR](https://github.com/Kilian/electron-to-chromium/pull/14) which means we can (hopefully) save atleast 8 MB of everyone's harddrive worldwide.

Also solves #213 