### PR TITLE
Change defaults: >0.3% instead of (>1% + last 2 versions)

### DIFF
--- a/index.js
+++ b/index.js
@@ -256,8 +256,9 @@ browserslist.usage = {
 
 // Default browsers query
 browserslist.defaults = [
-  '> 1%',
-  'last 2 versions',
+  '> 0.3%',
+  'last 2 Chrome versions',
+  'last 2 Firefox versions',
   'Firefox ESR'
 ]
 


### PR DESCRIPTION
This drops support for unused browsers - like QQ, Baidu, Blackberry, Opera Mobile, and IE 10; and adds back support for Chrome 49, which is the last release for Windows < 7 (still has 0,9% globally).

I'm still keeping last 2 Chrome and last 2 Firefox versions - as they're released really frequently, and it's possible that somebody haven't updated yet.