### PR TITLE
Proposal: `cover 70% in my stats` query

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ You can specify the versions by queries (case insensitive):
 * `> 5% in alt-AS`: uses Asia region usage statistics. List of all region codes
   can be found at [`caniuse-lite/data/regions`].
 * `> 5% in my stats`: uses [custom usage data].
+* `cover 70% of my stats`: most popular browsers that provide coverage, uses [custom usage data].
 * `extends browserslist-config-mycompany`: take queries from
   `browserslist-config-mycompany` npm package.
 * `ie 6-8`: selects an inclusive range of versions.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ You can specify the versions by queries (case insensitive):
 * `> 5% in alt-AS`: uses Asia region usage statistics. List of all region codes
   can be found at [`caniuse-lite/data/regions`].
 * `> 5% in my stats`: uses [custom usage data].
-* `cover 70% of my stats`: most popular browsers that provide coverage, uses [custom usage data].
+* `cover 70%`: most popular browsers that provide coverage
+* `cover 70% in US`: same as above, with [two-letter country code].
+* `cover 70% in my stats`: uses [custom usage data].
 * `extends browserslist-config-mycompany`: take queries from
   `browserslist-config-mycompany` npm package.
 * `ie 6-8`: selects an inclusive range of versions.

--- a/index.js
+++ b/index.js
@@ -529,6 +529,34 @@ var QUERIES = [
     }
   },
   {
+    regexp: /^cover\s+(\d*\.?\d+)%\s+of\s+my\s+stats$/,
+    select: function (context, desiredCoverage) {
+      desiredCoverage = parseFloat(desiredCoverage)
+
+      if (!context.customUsage) {
+        throw new BrowserslistError('Custom usage statistics was not provided')
+      }
+
+      var usageByPopularity = Object.keys(context.customUsage).sort(
+        function (a, b) {
+          // sort by descending popularity
+          return context.customUsage[b] - context.customUsage[a]
+        }
+      )
+
+      var result = []
+      var coveragePercent = 0
+      usageByPopularity.some(function (version) {
+        if (coveragePercent >= desiredCoverage) return true
+        if (context.customUsage[version] === 0) return true
+        coveragePercent += context.customUsage[version]
+        result.push(version)
+        return false
+      })
+      return result
+    }
+  },
+  {
     regexp: /^electron\s+([\d.]+)\s*-\s*([\d.]+)$/i,
     select: function (context, from, to) {
       if (!e2c[from]) {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "7 KB"
+      "limit": "7.5 KB"
     }
   ],
   "scripts": {

--- a/test/cover.test.js
+++ b/test/cover.test.js
@@ -1,0 +1,33 @@
+var browserslist = require('../')
+
+var path = require('path')
+
+var CUSTOM_STATS = path.join(__dirname, 'fixtures', 'stats.json')
+beforeEach(() => {
+  process.env.BROWSERSLIST_STATS = CUSTOM_STATS
+})
+afterEach(() => {
+  delete process.env.BROWSERSLIST_STATS
+})
+
+it('adds at least one browser', () => {
+  expect(browserslist('cover 1% of my stats')).toEqual(['ie 11'])
+})
+
+it('adds browsers by popularity', () => {
+  expect(browserslist('cover 20% of my stats')).toEqual(
+    ['chrome 37', 'chrome 36', 'ie 11', 'ie 10']
+  )
+})
+
+it('does not add zero-popularity', () => {
+  expect(browserslist('cover 20% of my stats', {
+    stats: { ie: { '11': 10, '10': 0 } } })).toEqual(['ie 11'])
+})
+
+it('throws error on no stats', () => {
+  delete process.env.BROWSERSLIST_STATS
+  expect(function () {
+    browserslist('cover 70% of my stats')
+  }).toThrowError(/statistics was not provided/)
+})

--- a/test/cover.test.js
+++ b/test/cover.test.js
@@ -3,31 +3,61 @@ var browserslist = require('../')
 var path = require('path')
 
 var CUSTOM_STATS = path.join(__dirname, 'fixtures', 'stats.json')
+
+var originUsage = browserslist.usage
+
 beforeEach(() => {
   process.env.BROWSERSLIST_STATS = CUSTOM_STATS
+  browserslist.usage = {
+    global: {
+      'ie 5': 50,
+      'ie 11': 10
+    },
+    US: {
+      'ie 8': 2,
+      'ie 9': 4.4
+    },
+    'alt-us': {
+      'ie 8': 25,
+      'ie 9': 10
+    }
+  }
 })
 afterEach(() => {
   delete process.env.BROWSERSLIST_STATS
+  browserslist.usage = originUsage
 })
 
 it('adds at least one browser', () => {
-  expect(browserslist('cover 1% of my stats')).toEqual(['ie 11'])
+  expect(browserslist('cover 1% in my stats')).toEqual(['ie 11'])
+})
+
+it('global coverage', () => {
+  expect(browserslist('cover 0.1%')).toEqual(['ie 5'])
+})
+
+it('country coverage', () => {
+  expect(browserslist('cover 0.1% in US')).toEqual(['ie 9'])
+})
+
+it('country coverage alt', () => {
+  expect(browserslist('cover 0.1% in alt-us')).toEqual(['ie 8'])
 })
 
 it('adds browsers by popularity', () => {
-  expect(browserslist('cover 20% of my stats')).toEqual(
+  expect(browserslist('cover 20% in my stats')).toEqual(
     ['chrome 37', 'chrome 36', 'ie 11', 'ie 10']
   )
 })
 
 it('does not add zero-popularity', () => {
-  expect(browserslist('cover 20% of my stats', {
+  expect(browserslist('cover 20% in my stats', {
     stats: { ie: { '11': 10, '10': 0 } } })).toEqual(['ie 11'])
 })
 
 it('throws error on no stats', () => {
   delete process.env.BROWSERSLIST_STATS
   expect(function () {
-    browserslist('cover 70% of my stats')
+    browserslist('cover 70% in my stats')
   }).toThrowError(/statistics was not provided/)
 })


### PR DESCRIPTION
When working on projects with existing audiences there're times when you want to cover most of your gathered stats.

This PR adds query `cover 70% in my stats` that returns most popular browsers that cover provided percent of custom stats when combined.